### PR TITLE
Implement pay and withdraw flows in a new tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist-newstyle/
+TAGS

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This repository contains two projects:
 
 * [lnurl][1] - A Haskell library for working with the LNURL standard
 * [lnurl-authenticator][2] - A command line tool for managing LNURL-auth identities
+* [lnurl-payment-tool][3] - A command line tool implementing LNURL-pay and LNURL-withdraw
 
 [1]: lnurl/
 [2]: lnurl-authenticator/
+[3]: lnurl-payment-tool/

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages:
   ./lnurl
   ./lnurl-authenticator
+  ./lnurl-payment-tool

--- a/hie.yaml
+++ b/hie.yaml
@@ -3,6 +3,12 @@ cradle:
     - path: "./lnurl/src"
       component: "lib:lnurl"
 
+    - path: "./lnurl-payment-tool/exec/Main.hs"
+      component: "lnurl-payment-tool:exe:lnurl-payment-tool"
+
+    - path: "./lnurl-payment-tool/src"
+      component: "lnurl-payment-tool:exe:lnurl-payment-tool"
+
     - path: "./lnurl-authenticator/src"
       component: "lib:lnurl-authenticator"
 

--- a/lnurl-authenticator/CHANGELOG.md
+++ b/lnurl-authenticator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for lnurl-authenticator
 
+## 0.1.0.1 -- 2022-07-29
+
+* Updates dependencies
+
 ## 0.1.0.0 -- 2021-07-29
 
 * First version. Released on an unsuspecting world.

--- a/lnurl-authenticator/lnurl-authenticator.cabal
+++ b/lnurl-authenticator/lnurl-authenticator.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.4
 name: lnurl-authenticator
 synopsis: A command line tool to manage LNURL auth identities
 description: See https://github.com/GambolingPangolin/lnurl/blob/master/lnurl-authenticator/README.md
-version: 0.1.0.0
+version: 0.1.0.1
 license: BSD-3-Clause
 license-file: LICENSE
 author: Ian Shipman
@@ -29,27 +29,27 @@ common core
         -fno-warn-unused-do-bind
 
     build-depends:
-      base >=4.14 && <4.16
+      base >=4.14 && <4.17
 
 library
     import: core
     hs-source-dirs: src
     build-depends:
-        aeson ^>=1.5
+        aeson >=1.5 && <2.2
       , bech32 ^>=1.1
       , bytestring >=0.10 && <0.12
       , containers ^>=0.6
-      , cryptonite ^>=0.29
+      , cryptonite >=0.29 && <0.31
       , directory ^>=1.3
       , filepath ^>=1.4
       , haskeline ^>=0.8
-      , haskoin-core ^>=0.20
+      , haskoin-core >=0.20 && <0.22
       , http-client ^>=0.7
       , http-client-tls ^>=0.3
       , lnurl ^>=0.1
-      , memory ^>=0.16
-      , text ^>=1.2
-      , time >=1.9 && <1.13
+      , memory >=0.16 && <0.18
+      , text >=1.2 && <2.1
+      , time >=1.9 && <1.14
 
     exposed-modules:
         LnUrl.Authenticator
@@ -63,4 +63,4 @@ executable lnurl-authenticator
     build-depends:
         Clipboard ^>=2.3
       , lnurl-authenticator
-      , optparse-applicative ^>=0.16
+      , optparse-applicative >=0.16 && <0.18

--- a/lnurl-authenticator/src/LnUrl/Authenticator/Storage.hs
+++ b/lnurl-authenticator/src/LnUrl/Authenticator/Storage.hs
@@ -143,7 +143,8 @@ encryptJsonFile userKey path value = do
     BS.writeFile path $
         salt
             <> convert iv
-            <> ( cbcEncrypt aes iv . pad paddingScheme
+            <> ( cbcEncrypt aes iv
+                    . pad paddingScheme
                     . BSL.toStrict
                     . encode
                )

--- a/lnurl-payment-tool/CHANGELOG.md
+++ b/lnurl-payment-tool/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for lnurl-payment-tool
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/lnurl-payment-tool/CHANGELOG.md
+++ b/lnurl-payment-tool/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Revision history for lnurl-payment-tool
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.1.0.0 -- 2022-07-29
 
 * First version. Released on an unsuspecting world.

--- a/lnurl-payment-tool/LICENSE
+++ b/lnurl-payment-tool/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2022, Ian Shipman
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Ian Shipman nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lnurl-payment-tool/README.md
+++ b/lnurl-payment-tool/README.md
@@ -1,0 +1,19 @@
+# lnurl-payment-tool
+
+_Warning:_ This is alpha software.  We welcome tester feedback and patches.
+
+This tool exposes two commands `withdraw` and `pay` each of which take an LNURL string (with optional `lightning:` prefix).  Each tool steps the user through the workflow, asking the user to supply amounts and pay or generate invoices via their LN wallet.  Privacy conscious users may couple this tool with tor.  For example:
+
+```console
+$ torify lnurl-payment-tool withdraw $LNURL
+```
+
+## Installation or development
+
+You will need haskell tooling.  Install `cabal` using your favorite package manager or [`ghcup`][1].  Add the `cabal` bin folder to your path, e.g. `~/.cabal/bin`.  Clone this repo.  Then from the repo root, run
+
+```console
+cabal build all && cabal install
+```
+
+[1]: https://www.haskell.org/ghcup/

--- a/lnurl-payment-tool/exec/Main.hs
+++ b/lnurl-payment-tool/exec/Main.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Applicative ((<**>))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import LnUrl.Tool.Pay (pay)
+import LnUrl.Tool.Withdraw (withdraw)
+import Network.HTTP.Client.TLS (newTlsManager)
+import qualified Options.Applicative as Opt
+
+data Command = Withdraw Text | Pay Text
+
+getCommand :: IO Command
+getCommand = Opt.execParser $ Opt.info (opts <**> Opt.helper) desc
+  where
+    opts =
+        Opt.hsubparser $
+            Opt.command "withdraw" cmdWithdraw
+                <> Opt.command "pay" cmdPay
+    cmdWithdraw = Opt.info (Withdraw <$> optLNURL) $ Opt.progDesc "Withdraw workflow"
+    cmdPay = Opt.info (Pay <$> optLNURL) $ Opt.progDesc "Pay workflow"
+    optLNURL = fmap (dropProto . Text.pack) . Opt.strArgument $ Opt.metavar "LNURL"
+    dropProto lnurl
+        | "lightning:" == Text.take 10 lnurl = Text.drop 10 lnurl
+        | otherwise = lnurl
+
+    desc = Opt.progDesc "LNURL payment tool"
+
+main :: IO ()
+main = do
+    mgr <- newTlsManager
+    getCommand >>= \case
+        Withdraw lnurl -> withdraw mgr lnurl
+        Pay lnurl -> pay mgr lnurl

--- a/lnurl-payment-tool/lnurl-payment-tool.cabal
+++ b/lnurl-payment-tool/lnurl-payment-tool.cabal
@@ -1,0 +1,36 @@
+cabal-version: 2.4
+name: lnurl-payment-tool
+synopsis: Command line tool for the LNURL pay, withdraw, and channel workflows
+description: See https://github.com/GambolingPangolin/lnurl/blob/master/lnurl-payment-tool/README.md
+version: 0.1.0.0
+license: BSD-3-Clause
+license-file: LICENSE
+author: Ian Shipman
+maintainer: ics@gambolingpangolin.com
+extra-source-files: CHANGELOG.md
+
+executable lnurl-payment-tool
+    main-is: Main.hs
+    hs-source-dirs: exec, src
+    default-language: Haskell2010
+
+    other-modules:
+        LnUrl.Tool.Pay
+        LnUrl.Tool.Utils
+        LnUrl.Tool.Withdraw
+
+    build-depends:
+        aeson >=1.5 && <2.2
+      , base ^>=4.16.1.0
+      , base16 ^>=0.3
+      , base64 ^>=0.4
+      , bech32 ^>=1.1
+      , bytestring >=0.10 && <0.12
+      , cryptonite >=0.29 && <0.31
+      , http-client ^>=0.7
+      , http-client-tls ^>=0.3
+      , lnurl ^>=0.1
+      , memory >=0.16 && <0.18
+      , network-uri >=2.6 && <2.8
+      , optparse-applicative >=0.16 && <0.18
+      , text >=1.2 && <2.2

--- a/lnurl-payment-tool/src/LnUrl/Tool/Pay.hs
+++ b/lnurl-payment-tool/src/LnUrl/Tool/Pay.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module LnUrl.Tool.Pay (pay) where
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.Internal as Bech32
+import Control.Exception (Exception, throwIO)
+import Control.Monad ((>=>))
+import qualified Crypto.Hash as C
+import Crypto.Random (getRandomBytes)
+import qualified Data.Aeson as Ae
+import Data.Bifunctor (first)
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.ByteString.Char8 as BS8
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Text.IO as TIO
+import qualified Data.Text.Read as TR
+import Data.Word (Word64)
+import LnUrl.Pay (
+    CallbackSuccessResponse,
+    Metadata (..),
+    Response (..),
+    SuccessAction (..),
+    SuccessResponse,
+ )
+import qualified LnUrl.Pay as P
+import LnUrl.Tool.Utils (decodeBech32URL, jsonRequest, toSats)
+import Network.HTTP.Client (Manager)
+import qualified Network.HTTP.Client as Http
+import Network.URI (URI)
+import Text.Read (readMaybe)
+
+pay :: Manager -> Text -> IO ()
+pay mgr =
+    either throwPayException pure . decodeBech32URL
+        >=> firstRequest mgr
+        >=> getCallbackKit
+        >=> callback mgr
+        >=> mapM_ onSuccessAction
+
+-- | Initiate the payment flow
+firstRequest :: Manager -> Text -> IO SuccessResponse
+firstRequest mgr =
+    Http.parseRequest . Text.unpack
+        >=> jsonRequest mgr
+        >=> either throwPayException getResponse
+
+-- | Decode the metadata field and get the unique text metadata entry
+getTextMetadata :: SuccessResponse -> IO Text
+getTextMetadata =
+    ( either (throwPayException . Text.pack) pure
+        . Ae.eitherDecodeStrict
+        . encodeUtf8
+        . P.metadata
+    )
+        >=> onTextCandidates . mapMaybe toTextMetadata
+  where
+    toTextMetadata = \case
+        PlainText text -> Just text
+        _ -> Nothing
+    onTextCandidates = \case
+        [textMetadata] -> pure textMetadata
+        _ -> throwPayException "Malformed response: expected exactly one text metadata"
+
+data CallbackKit = CallbackKit
+    { callbackURL :: URI
+    , amount :: Word64
+    , metadataHash :: ByteString
+    }
+
+-- | Interact with the user to get an amount and generate a callback URL
+getCallbackKit :: SuccessResponse -> IO CallbackKit
+getCallbackKit successResponse = do
+    textMetadata <- getTextMetadata successResponse
+    TIO.putStrLn $ "Text metadata: " <> textMetadata
+    TIO.putStrLn $
+        Text.unwords
+            [ "Pay between"
+            , (Text.pack . show . toSats) (P.minSendable successResponse)
+            , "sats and"
+            , (Text.pack . show . toSats) (P.maxSendable successResponse)
+            ]
+    TIO.putStrLn "Payment amount:"
+    amount <- getLine >>= maybe (badAmount) (pure . fromSats) . readMaybe
+    cachePrevention <- getRandomBytes 32
+    callbackURL <-
+        maybe noURI pure $
+            P.getCallbackUrl
+                successResponse
+                amount
+                (Just cachePrevention)
+                mempty -- No route hints
+                Nothing -- No comment
+                Nothing -- No proof of payer
+    pure
+        CallbackKit
+            { callbackURL
+            , amount
+            , metadataHash =
+                BA.convert
+                    . C.hashWith C.SHA256
+                    . encodeUtf8
+                    $ P.metadata successResponse
+            }
+  where
+    badAmount = throwPayException "Unable to parse amount"
+    noURI = throwPayException "Unable to construct URI"
+    fromSats = floor @Double . (* 1000)
+
+{- | Perform the callback and verify that the response is well-formed by checking that:
+ 1. The requested amount matches
+ 2. The "purpose of payment" field matches the metadata hash
+-}
+callback :: Manager -> CallbackKit -> IO (Maybe SuccessAction)
+callback mgr callbackKit =
+    (Http.parseRequest . show . callbackURL) callbackKit
+        >>= jsonRequest mgr
+        >>= either throwPayException getResponse
+        >>= (verifyResponse <$> amount <*> metadataHash) callbackKit
+
+verifyResponse ::
+    -- | Expected amount
+    Word64 ->
+    -- | Expected metadata hash
+    ByteString ->
+    CallbackSuccessResponse ->
+    IO (Maybe SuccessAction)
+verifyResponse expectedAmount expectedHash callbackResponse
+    | Left err <- requestFields =
+        throwPayException $ "Unable to decode payment request: " <> err
+    | Right (requestAmount, _) <- requestFields
+    , expectedAmount /= requestAmount =
+        throwPayException "Invalid amount"
+    | Right (_, requestHash) <- requestFields
+    , expectedHash /= requestHash =
+        throwPayException $
+            "Invalid metadata hash: expected "
+                <> B16.encodeBase16 expectedHash
+                <> " but got "
+                <> B16.encodeBase16 requestHash
+    | otherwise = do
+        TIO.putStrLn $ "Please pay: " <> P.paymentRequest callbackResponse
+        pure $ P.successAction callbackResponse
+  where
+    requestFields = parsePaymentRequest $ P.paymentRequest callbackResponse
+
+parsePaymentRequest :: Text -> Either Text (Word64, ByteString)
+parsePaymentRequest =
+    first (const "Bech32 decoding error") . Bech32.decodeLenient
+        >=> onBech32Values
+  where
+    onBech32Values (hr, dataPart) =
+        (,)
+            <$> getAmount (Bech32.humanReadablePartToText hr)
+            <*> onDataWords (Bech32.dataPartToWords dataPart)
+
+    noDataBytes = Left "Unable to parse data part"
+
+    -- Drop the 35 bit timestamp then look for the h field
+    onDataWords = getHash . drop 7
+
+    getAmount hr
+        | "lnbc" == Text.take 4 hr =
+            (first Text.pack . TR.decimal) (Text.drop 4 hr) >>= toAmount
+        | otherwise = Left "Unable to get amount"
+
+    -- Convert the amount to millisatoshis
+    toAmount (value, multiplier) = case multiplier of
+        -- millibitcoin
+        "m" -> pure $ 10 ^ (8 - 3 + 3) * value
+        -- microbitcoin
+        "u" -> pure $ 10 ^ (8 - 6 + 3) * value
+        -- nanobitcoin
+        "n" -> pure $ 10 ^ (8 - 9 + 3) * value
+        -- picobitcoin
+        "p" -> pure $ value `quot` 10
+        _ -> Left "Unknown multiplier"
+
+    getHash = \case
+        ws@(w0 : l1 : l0 : remaining)
+            -- All that remains is the signature
+            | length ws <= 520 `quot` 5 -> noH
+            -- Look for the h tag
+            | w0 == toEnum 23
+            , Just bytes <- hashBytes remaining ->
+                pure . BS.pack $ take 32 bytes
+            | otherwise -> getHash $ drop (32 * fromEnum l1 + fromEnum l0) remaining
+        _ -> noH
+
+    noH = Left "Unable to find h field"
+
+    hashBytes ws = Bech32.toBase256 $ take 52 ws <> (toEnum <$> [0x00, 0x00, 0x00, 0x00])
+
+-- | Display the success action so that the user can take further steps
+onSuccessAction :: SuccessAction -> IO ()
+onSuccessAction = \case
+    Url url ->
+        TIO.putStrLn $
+            "URL action (" <> P.urlDescription url <> "): " <> (Text.pack . show . P.url) url
+    Message text ->
+        TIO.putStrLn $ "Message: " <> text
+    Aes aes -> do
+        TIO.putStrLn $ "Encrypted payload."
+        TIO.putStrLn $ "Enter payment preimage:"
+        preimage <- getPreimage
+        either (throwPayException . Text.pack . show) onPlaintext (P.decrypt preimage aes)
+  where
+    onPlaintext bytes = TIO.putStrLn $ "Plaintext: " <> B64.encodeBase64 bytes
+    getPreimage = BS8.getLine >>= either throwPayException pure . B16.decodeBase16
+
+getResponse :: Response a -> IO a
+getResponse = \case
+    Success x -> pure x
+    ErrorResponse msg -> throwPayException msg
+
+newtype PayException = PayException Text
+    deriving (Eq, Show)
+
+instance Exception PayException
+
+throwPayException :: Text -> IO a
+throwPayException = throwIO . PayException

--- a/lnurl-payment-tool/src/LnUrl/Tool/Utils.hs
+++ b/lnurl-payment-tool/src/LnUrl/Tool/Utils.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LnUrl.Tool.Utils (
+    decodeBech32URL,
+    jsonRequest,
+    toSats,
+) where
+
+import qualified Codec.Binary.Bech32 as Bech32
+import Data.Aeson (FromJSON)
+import qualified Data.Aeson as Ae
+import Data.Bifunctor (first)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Text.Encoding (decodeUtf8)
+import Data.Word (Word64)
+import Network.HTTP.Client (Manager, Request)
+import qualified Network.HTTP.Client as Http
+
+decodeBech32URL :: Text -> Either Text Text
+decodeBech32URL = either onDecodeError onResult . Bech32.decodeLenient
+  where
+    onResult (hr, dataPart)
+        | Bech32.humanReadablePartToText hr == "lnurl"
+        , Just bytes <- Bech32.dataPartToBytes dataPart =
+            pure $ decodeUtf8 bytes
+        | otherwise = Left "Unable to interpret LNURL"
+    onDecodeError _ = Left "Unable to decode Bech32"
+
+jsonRequest :: FromJSON a => Manager -> Request -> IO (Either Text a)
+jsonRequest mgr request =
+    first Text.pack . Ae.eitherDecode . Http.responseBody <$> Http.httpLbs request mgr
+
+-- | Convert millisatoshi to satoshi
+toSats :: Word64 -> Double
+toSats = (/ 1000) . fromIntegral

--- a/lnurl-payment-tool/src/LnUrl/Tool/Withdraw.hs
+++ b/lnurl-payment-tool/src/LnUrl/Tool/Withdraw.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module LnUrl.Tool.Withdraw (withdraw) where
+
+import qualified Codec.Binary.Bech32 as Bech32
+import Control.Exception (Exception, throwIO)
+import Control.Monad ((>=>))
+import qualified Data.Aeson as Ae
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TIO
+import LnUrl.Tool.Utils (decodeBech32URL, jsonRequest, toSats)
+import LnUrl.Withdraw (AckResponse (..), Response (..), SuccessResponse)
+import qualified LnUrl.Withdraw as W
+import Network.HTTP.Client (Manager)
+import qualified Network.HTTP.Client as Http
+import Network.URI (URI)
+
+withdraw ::
+    Manager ->
+    -- | LNURL
+    Text ->
+    IO ()
+withdraw mgr =
+    either throwWithdrawException pure . decodeBech32URL
+        >=> firstRequest mgr
+        >=> getWithdrawURI
+        >=> secondRequest mgr
+  where
+
+firstRequest :: Manager -> Text -> IO SuccessResponse
+firstRequest mgr url = do
+    TIO.putStrLn $ "Trying " <> url
+    Http.parseRequest (Text.unpack url)
+        >>= jsonRequest mgr
+        >>= either throwWithdrawException onResponse
+  where
+    onResponse = \case
+        Success x -> pure x
+        ErrorResponse msg -> throwWithdrawException msg
+
+type PaymentRequest = Text
+
+getWithdrawURI :: SuccessResponse -> IO URI
+getWithdrawURI successResponse = do
+    TIO.putStrLn $
+        Text.unwords
+            [ "You can withdraw between"
+            , (Text.pack . show . toSats) (W.minWithdrawable successResponse)
+            , "sats and"
+            , (Text.pack . show . toSats) (W.maxWithdrawable successResponse)
+            , "sats"
+            ]
+    TIO.putStrLn "Please enter the payment request."
+    paymentRequest <- TIO.getLine
+    pure $ W.getCallbackURL successResponse paymentRequest Nothing
+
+secondRequest :: Manager -> URI -> IO ()
+secondRequest mgr withdrawURI =
+    Http.parseRequest (show withdrawURI)
+        >>= jsonRequest mgr
+        >>= either throwWithdrawException onResponse
+  where
+    onResponse = \case
+        AckSuccess -> TIO.putStrLn "Success!"
+        AckError msg -> throwWithdrawException msg
+
+newtype WithdrawException = WithdrawException Text
+    deriving (Eq, Show)
+
+instance Exception WithdrawException
+
+throwWithdrawException :: Text -> IO a
+throwWithdrawException = throwIO . WithdrawException

--- a/lnurl/CHANGELOG.md
+++ b/lnurl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for lnurl
 
+## 0.1.0.1 -- 2022-07-29
+
+* Updates dependencies
+* Changes the `metadatada` field in the payment flow success response to text so
+  that we can calculate hashes over it correctly
+
 ## 0.1.0.0 -- 2021-07-29 
 
 * First version. Released on an unsuspecting world.

--- a/lnurl/lnurl.cabal
+++ b/lnurl/lnurl.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.4
 name: lnurl
 synopsis: Support for developing against the LNURL protocol
 description: See https://github.com/GambolingPangolin/lnurl/blob/master/lnurl/README.md
-version: 0.1.0.0
+version: 0.1.0.1
 license: BSD-3-Clause
 license-file: LICENSE
 author: Ian Shipman
@@ -41,16 +41,16 @@ library
         Network.URI.Utils
 
     build-depends:
-          aeson ^>=1.5
-        , base >=4.14 && <4.15
+          aeson >=2.0 && <2.2
+        , base >=4.14 && <4.17
         , base16 ^>=0.3
         , base64 ^>=0.4
         , bytestring >=0.10 && <0.12
         , cereal ^>=0.5
-        , cryptonite ^>=0.29
+        , cryptonite >=0.29 && <0.31
         , extra ^>=1.7
-        , haskoin-core ^>=0.20
+        , haskoin-core >=0.20 && <0.22
         , http-types ^>=0.12
-        , memory ^>=0.16
+        , memory >=0.16 && <0.18
         , network-uri >=2.6 && <2.8
-        , text ^>=1.2
+        , text >=1.2 && <2.1

--- a/lnurl/src/LnUrl/Channel.hs
+++ b/lnurl/src/LnUrl/Channel.hs
@@ -49,12 +49,12 @@ import Network.URI.Utils (addQueryParams)
 
 -- | @LN SERVICE@ responds with 'Response' 'SuccessResponse'
 data SuccessResponse = SuccessResponse
-    { -- | Remote node URI
-      remoteNode :: ByteString
-    , -- | Service URL
-      callback :: URI
-    , -- | Wallet identifier
-      k1 :: ByteString
+    { remoteNode :: ByteString
+    -- ^ Remote node URI
+    , callback :: URI
+    -- ^ Service URL
+    , k1 :: ByteString
+    -- ^ Wallet identifier
     }
     deriving (Eq, Show)
 

--- a/lnurl/src/LnUrl/Pay.hs
+++ b/lnurl/src/LnUrl/Pay.hs
@@ -64,7 +64,6 @@ import Data.Aeson (
     (.:?),
     (.=),
  )
-import qualified Data.Aeson as Ae
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -77,7 +76,6 @@ import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
-import qualified Data.Text.Lazy.Encoding as TL
 import Data.Word (Word64)
 import Haskoin (PubKey, exportPubKey)
 import LnUrl (NodeId, Response (..))
@@ -110,7 +108,7 @@ instance FromJSON SuccessResponse where
             <$> (getJsonURI <$> obj .: "callback")
             <*> obj .: "maxSendable"
             <*> obj .: "minSendable"
-            <*> (obj .: "metadata" >>= either fail pure . Ae.eitherDecode . TL.encodeUtf8)
+            <*> (obj .: "metadata")
             <*> obj .:? "commentAllowed"
 
 instance ToJSON SuccessResponse where
@@ -119,7 +117,7 @@ instance ToJSON SuccessResponse where
             [ "callback" .= (JsonURI . callback) response
             , "maxSendable" .= maxSendable response
             , "minSendable" .= minSendable response
-            , "metadata" .= (TL.decodeUtf8 . Ae.encode . metadata) response
+            , "metadata" .= metadata response
             ]
                 <> catMaybes ["commentAllowed" .=? commentAllowed response]
 
@@ -129,7 +127,7 @@ data SuccessResponse = SuccessResponse
     -- ^ millisatoshi
     , minSendable :: Word64
     -- ^ millisatoshi
-    , metadata :: [Metadata]
+    , metadata :: Text
     , commentAllowed :: Maybe Int
     }
     deriving (Eq, Show)

--- a/lnurl/src/LnUrl/Pay.hs
+++ b/lnurl/src/LnUrl/Pay.hs
@@ -125,10 +125,10 @@ instance ToJSON SuccessResponse where
 
 data SuccessResponse = SuccessResponse
     { callback :: URI
-    , -- | millisatoshi
-      maxSendable :: Word64
-    , -- | millisatoshi
-      minSendable :: Word64
+    , maxSendable :: Word64
+    -- ^ millisatoshi
+    , minSendable :: Word64
+    -- ^ millisatoshi
     , metadata :: [Metadata]
     , commentAllowed :: Maybe Int
     }

--- a/lnurl/src/LnUrl/Utils.hs
+++ b/lnurl/src/LnUrl/Utils.hs
@@ -9,6 +9,7 @@ module LnUrl.Utils (
 
 import Data.Aeson (
     FromJSON,
+    Key,
     ToJSON,
     Value,
     parseJSON,
@@ -19,7 +20,6 @@ import Data.Aeson (
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 (decodeBase16, encodeBase16)
 import Data.ByteString.Base64 (decodeBase64, encodeBase64)
-import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Network.URI (URI, parseURI)
@@ -61,5 +61,5 @@ instance FromJSON JsonURI where
 instance ToJSON JsonURI where
     toJSON = toJSON . show . getJsonURI
 
-(.=?) :: ToJSON a => Text -> Maybe a -> Maybe (Text, Value)
+(.=?) :: ToJSON a => Key -> Maybe a -> Maybe (Key, Value)
 k .=? mv = (k .=) <$> mv

--- a/lnurl/src/LnUrl/Withdraw.hs
+++ b/lnurl/src/LnUrl/Withdraw.hs
@@ -49,12 +49,12 @@ data SuccessResponse = SuccessResponse
     { callback :: URI
     , challenge :: Text
     , defaultDescription :: Text
-    , -- | millisatoshis
-      minWithdrawable :: Word64
-    , -- | millisatoshis
-      maxWithdrawable :: Word64
-    , -- | URL to use to make a subsequent LNURL-withdraw request, response with 'SuccessResponse'
-      balanceCheck :: Maybe URI
+    , minWithdrawable :: Word64
+    -- ^ millisatoshis
+    , maxWithdrawable :: Word64
+    -- ^ millisatoshis
+    , balanceCheck :: Maybe URI
+    -- ^ URL to use to make a subsequent LNURL-withdraw request, response with 'SuccessResponse'
     }
     deriving (Eq, Show)
 
@@ -82,6 +82,7 @@ instance ToJSON SuccessResponse where
 -- | Use the first response to build the callback url
 getCallbackURL ::
     SuccessResponse ->
+    -- | Payment request
     Text ->
     -- | URL where @LN SERVICE@ can POST 'SuccessResponse' values to notify the wallet
     Maybe URI ->


### PR DESCRIPTION
This introduces a command line tool `lnurl-payment-tool` to walk users through the payment and withdraw flows.